### PR TITLE
feat: add icon property to avatar; make avatar sizes to theme

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -8,88 +8,89 @@ const AvatarWrapper = styled.span`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: ${({ theme }) => theme.spacing(3)};
-  height: ${({ theme }) => theme.spacing(3)};
-  font-size: calc(${({ theme }) => theme.spacing(3)} / 2.2);
-  background-color: ${({ theme }) => theme.primary};
+  width: ${({ theme }) => theme.avatarSizes?.default};
+  height: ${({ theme }) => theme.avatarSizes?.default};
+  font-size: calc(${({ theme }) => theme.avatarSizes?.default} / 2);
+  background: ${({ theme }) => theme.primary};
   color: #fff;
   border-radius: 100%;
   background-size: cover;
   background-position: center center;
   text-transform: uppercase;
 
-  ${props =>
-    props.size === 'tiny' &&
-    css`
-      height: ${({ theme }) => theme.spacing(1.5)};
-      width: ${({ theme }) => theme.spacing(1.5)};
-      font-size: calc(${({ theme }) => theme.spacing(1.5)} / 2.2);
+  ${({ size, theme }) =>
+    Boolean(size) &&
+    Boolean(theme?.avatarSizes?.[size]) &&
+    `
+      width: ${theme?.avatarSizes?.[size]};
+      height: ${theme?.avatarSizes?.[size]};
+      font-size: calc(${theme?.avatarSizes?.[size]} / 2);
     `};
 
-  ${props =>
-    props.size === 'small' &&
+  ${({ variant }) =>
+    variant === 'rounded' &&
     css`
-      height: ${({ theme }) => theme.spacing(2)};
-      width: ${({ theme }) => theme.spacing(2)};
-      font-size: calc(${({ theme }) => theme.spacing(2)} / 2.2);
-    `};
+      border-radius: ${({ theme }) => theme.borderRadius?.default};
+    `}
 
-  ${props =>
-    props.size === 'medium' &&
+  ${({ variant }) =>
+    variant === 'square' &&
     css`
-      height: ${({ theme }) => theme.spacing(4)};
-      width: ${({ theme }) => theme.spacing(4)};
-      font-size: calc(${({ theme }) => theme.spacing(4)} / 2.2);
-    `};
+      border-radius: 0;
+    `}
 
-  ${props =>
-    props.size === 'large' &&
+  ${({ background }) =>
+    Boolean(background) &&
     css`
-      height: ${({ theme }) => theme.spacing(6)};
-      width: ${({ theme }) => theme.spacing(6)};
-      font-size: calc(${({ theme }) => theme.spacing(6)} / 2.2);
-    `};
+      background: ${({ theme }) =>
+        theme.gradients?.[background] ||
+        theme.colors?.[background] ||
+        theme?.[background]};
+    `}
 
-  ${props =>
-    props.size === 'huge' &&
+  ${({ borderRadius }) =>
+    Boolean(borderRadius) &&
     css`
-      height: ${({ theme }) => theme.spacing(8)};
-      width: ${({ theme }) => theme.spacing(8)};
-      font-size: calc(${({ theme }) => theme.spacing(8)} / 2.2);
-    `};
-
-  ${props =>
-    props.variant === 'rounded' &&
-    css`
-      border-radius: ${({ theme }) => theme.borderRadius};
+      border-radius: ${({ theme }) => theme.borderRadius?.[borderRadius]};
     `}
 `;
 
-const Avatar = ({ firstName, lastName, size, imageUrl, ...props }) => (
+const getAvatarContent = ({ firstName, lastName, icon, imageUrl, name }) => {
+  if (Boolean(imageUrl)) {
+    return null;
+  }
+  if (Boolean(icon)) {
+    return icon;
+  }
+  if (Boolean(firstName) || Boolean(lastName)) {
+    return (
+      <span>
+        {trim(firstName || '').charAt(0)}
+        {trim(lastName || '').charAt(0)}
+      </span>
+    );
+  }
+  return <span>{(name || '').charAt(0)}</span>;
+};
+
+const Avatar = ({ size, imageUrl, ...props }) => (
   <AvatarWrapper
     size={size}
-    style={{ backgroundImage: `url(${imageUrl})` }}
+    style={{
+      backgroundImage: Boolean(imageUrl) ? `url(${imageUrl})` : undefined,
+    }}
     {...props}
   >
-    {!Boolean(imageUrl) && (
-      <>
-        {trim(firstName).charAt(0)}
-        {trim(lastName).charAt(0)}
-      </>
-    )}
+    {getAvatarContent({ imageUrl, ...props })}
   </AvatarWrapper>
 );
 
 Avatar.propTypes = {
   firstName: PropTypes.string,
   lastName: PropTypes.string,
+  name: PropTypes.string,
   imageUrl: PropTypes.string,
-  size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'huge']),
-};
-
-Avatar.defaultProps = {
-  firstName: '',
-  lastName: '',
+  size: PropTypes.string,
 };
 
 export default Avatar;

--- a/src/components/Avatar.stories.mdx
+++ b/src/components/Avatar.stories.mdx
@@ -1,7 +1,9 @@
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import { ThemeProvider } from 'styled-components';
 import { action } from '@storybook/addon-actions';
 import Avatar from './Avatar';
-import { Buttons } from '../ui';
+import { Stack, theme, injectMargaret } from '..';
+import { FaUserCircle } from 'react-icons/fa';
 
 <Meta
   title="Design System/Avatar"
@@ -11,47 +13,174 @@ import { Buttons } from '../ui';
 
 # Avatar
 
-Avatars are avatars.
-
 <Props of={Avatar} />
 
 ## Sizes
 
+Margaret provides defaults sizes: `default`, `tiny`, `small`, `medium`, `large` and `huge`.
+
 <Preview>
   <Story name="Sizes">
-    <Buttons verticalAlignment="center" alignment="left">
+    <Stack alignY="center" gutterSize={1}>
       <Avatar firstName="Nino" lastName="Quincampoix" size="small" />
       <Avatar firstName="Nino" lastName="Quincampoix" />
       <Avatar firstName="Nino" lastName="Quincampoix" size="medium" />
       <Avatar firstName="Nino" lastName="Quincampoix" size="large" />
-    </Buttons>
+    </Stack>
   </Story>
 </Preview>
 
-## Kinds
+Those size can be overriden using by setting a custom `theme.avatarSizes`. The default
+values are as is:
+
+```javascript
+const theme = {
+  ...
+  avatarSizes: {
+    tiny: '1rem',
+    small: '2rem',
+    default: '3rem',
+    medium: '4rem',
+    large: '6rem',
+    huge: '8rem',
+  },
+};
+```
+
+For instance, setting `theme.avatarSizes` as follow…
+
+```javascript
+const theme = {
+  ...
+  avatarSizes: {
+    micro: '32px',
+    default: '96px',
+    mega: '256px',
+  },
+};
+```
+
+…would give this results in-app.
+
+<Preview>
+  <Story name="Custom Sizes">
+    <ThemeProvider
+      theme={injectMargaret({
+        ...theme,
+        avatarSizes: {
+          micro: '32px',
+          default: '96px',
+          mega: '256px',
+        },
+      })}
+    >
+      <Stack alignY="center" gutterSize={1}>
+        <Avatar firstName="Nino" lastName="Quincampoix" size="micro" />
+        <Avatar firstName="Nino" lastName="Quincampoix" />
+        <Avatar firstName="Nino" lastName="Quincampoix" size="mega" />
+      </Stack>
+    </ThemeProvider>
+  </Story>
+</Preview>
+
+## Modes
+
+Avatar content can be provided via five props: `imageUrl`, `icon`, `firstName` + `lastName`, and `name`, in importance decreasing order.
 
 <Preview>
   <Story name="Kinds">
-    <Buttons verticalAlignment="center" alignment="left">
-      <Avatar imageUrl="https://picsum.photos/256/256" />
-      <Avatar firstName="Nino" lastName="Quincampoix" />
+    <Stack alignY="center" gutterSize={1}>
+      <Avatar
+        imageUrl="https://picsum.photos/256/256"
+        firstName="Nino"
+        lastName="Quincampoix"
+        name="Nino19"
+        icon={<FaUserCircle size={32} />}
+      />
       <Avatar
         firstName="Nino"
         lastName="Quincampoix"
-        imageUrl="https://picsum.photos/128/128"
+        name="Nino19"
+        icon={<FaUserCircle size={32} />}
       />
+      <Avatar firstName="Nino" lastName="Quincampoix" name="Nino19" />
+      <Avatar lastName="Quincampoix" name="Nino19" />
+      <Avatar name="Nino19" />
       <Avatar />
-    </Buttons>
+    </Stack>
   </Story>
 </Preview>
 
 ## Variants
 
+Three variants are provided. They set the avatar as round, rounded or square.
+
 <Preview>
   <Story name="Variants">
-    <Buttons verticalAlignment="center" alignment="left">
+    <Stack alignY="center" gutterSize={1}>
       <Avatar imageUrl="https://picsum.photos/256/256" />
       <Avatar imageUrl="https://picsum.photos/256/256" variant="rounded" />
-    </Buttons>
+      <Avatar imageUrl="https://picsum.photos/256/256" variant="square" />
+    </Stack>
+  </Story>
+</Preview>
+
+## Overrides
+
+The background and border radius can be overriden at the component level.
+If set, they take the value of the corresponding theme prop.
+
+For instance, using this theme…
+
+```javascript
+const theme = {
+  ...
+  borderRadius: {
+    huge: '32px',
+    ...
+  },
+  gradients: {
+    primaryGradient: 'linear-gradient(to bottom, #bada55, #c55)'
+    ...
+  },
+  colors: {
+    primary: '#bada55'
+    ...
+  },
+  secondary: '#c55'
+};
+```
+
+…would enable the following component-level customization:
+
+<Preview>
+  <Story name="Component-level customization">
+    <Stack alignY="center" gutterSize={1}>
+      <ThemeProvider
+        theme={injectMargaret({
+          ...theme,
+          borderRadius: {
+            ...theme.borderRadius,
+            huge: '32px',
+          },
+          gradients: {
+            primaryGradient: 'linear-gradient(to bottom, #f5aba5, #406fb3)',
+          },
+          colors: {
+            primary: '#406fb3',
+          },
+          secondary: '#f5aba5',
+        })}
+      >
+        <Avatar
+          size="huge"
+          icon={<FaUserCircle />}
+          background="primaryGradient"
+        />
+        <Avatar size="huge" icon={<FaUserCircle />} background="primary" />
+        <Avatar size="huge" icon={<FaUserCircle />} background="secondary" />
+        <Avatar size="huge" icon={<FaUserCircle />} borderRadius="huge" />
+      </ThemeProvider>
+    </Stack>
   </Story>
 </Preview>

--- a/src/components/Pills.js
+++ b/src/components/Pills.js
@@ -38,7 +38,7 @@ export const PillButton = styled(ButtonReset)`
   padding: ${({ theme }) => theme.spacing(0.5)}
     ${({ theme }) => theme.spacing(0.75)};
   display: block;
-  border-radius: ${({ theme }) => theme.borderRadius};
+  border-radius: ${({ theme }) => theme.borderRadius?.default};
   color: ${({ theme }) => theme.textLight};
   text-decoration: none;
   transition: box-shadow 150ms ease, background 150ms ease, color 150ms ease;

--- a/src/components/SegmentedControls.js
+++ b/src/components/SegmentedControls.js
@@ -4,7 +4,7 @@ import { Pills, PillItem, PillButton } from './Pills';
 
 const SegmentedWrapper = styled(Pills)`
   box-shadow: inset 0 0 0 1px ${({ theme }) => theme.separator};
-  border-radius: ${({ theme }) => theme.borderRadius};
+  border-radius: ${({ theme }) => theme.borderRadius?.default};
   overflow: hidden;
 `;
 

--- a/src/ui/cards.js
+++ b/src/ui/cards.js
@@ -3,7 +3,7 @@ import { media } from './utils';
 
 export const CardWrapper = styled.div`
   border: 1px solid ${({ theme }) => theme.separator};
-  border-radius: ${({ theme }) => theme.borderRadius};
+  border-radius: ${({ theme }) => theme.borderRadius?.default};
   overflow: hidden;
 
   ${({ fixedSize, theme }) =>

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -16,7 +16,12 @@ export const theme = {
 
   spacing,
 
-  borderRadius: '6px',
+  borderRadius: {
+    none: '0',
+    small: '4px',
+    default: '6px',
+    large: '12px',
+  },
 
   buttonsDefaultAlignX: 'flex-start',
   boxShadowColor: 'rgba(0, 0, 0, 0.12)',
@@ -211,5 +216,14 @@ export const theme = {
     narrow: '45rem',
     default: '75rem',
     full: '100%',
+  },
+
+  avatarSizes: {
+    tiny: '1rem',
+    small: '2rem',
+    default: '3rem',
+    medium: '4rem',
+    large: '6rem',
+    huge: '8rem',
   },
 };


### PR DESCRIPTION
BREAKING CHANGE: this commit replaces calls from theme.borderRadius to theme.borderRadius?.default.
All our apps using @tymate/margaret >= 2.0.0-alpha.1 must be updated. Good news is, we would
notice, because it would break during development

A quick find & replace theme.borderRadius} to theme.borderRadius?.default} would do the trick. 

Related to #13.